### PR TITLE
[SECTION-061] シグナルをハンドリングする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go build -trimpath -ldfags "-w -s" -o app
+RUN go build -trimpath -ldflags "-w -s" -o app
 
 # ---------------------------------------------
 

--- a/main.go
+++ b/main.go
@@ -7,12 +7,18 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/koh-yoshimoto/go_todo_app/config"
 	"golang.org/x/sync/errgroup"
 )
 
 func run(ctx context.Context) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	cfg, err := config.New()
 	if err != nil {
 		return err
@@ -25,6 +31,8 @@ func run(ctx context.Context) error {
 	log.Printf("start with: %v", url)
 	s := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// コマンドラインで実験するため
+			time.Sleep(5 * time.Second)
 			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
 		}),
 	}


### PR DESCRIPTION
Webアプリケーションのサーバーとして必要な機能の1つがグレースフルシャットダウン

> サーバーやコンテナが終了する場合、アプリケーションプロセスは終了プロセスを受け取る
> 何らかの処理を実行する際に終了シグナルを受け付けた場合、アプリケーションプロセスは処理を正常に完了させるまでに終了しないことが望ましい

Linuxのシグナルは様々であるが、今回ハンドリングするシグナルは以下の2つ

- `SIGINT`: 割り込みシグナル(Ctrl+C 押下時)
- `SIGTERM`: 終了シグナル(外部からの終了指示)