### PR TITLE
[SECTION-062] 「Server」構造体を定義する

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type Server struct {
+	srv *http.Server
+	l   net.Listener
+}
+
+func NewServer(l net.Listener, mux http.Handler) *Server {
+	return &Server{
+		srv: &http.Server{Handler: mux},
+		l:   l,
+	}
+}
+
+func (s *Server) Run(ctx context.Context) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		if err := s.srv.Serve(s.l); err != nil &&
+			err != http.ErrServerClosed {
+			log.Printf("failed to close: %+v", err)
+			return err
+		}
+		return nil
+	})
+
+	<-ctx.Done()
+	if err := s.srv.Shutdown(context.Background()); err != nil {
+		log.Printf("failed to shutdown: %+v", err)
+	}
+
+	return eg.Wait()
+}

--- a/server_test.go
+++ b/server_test.go
@@ -26,8 +26,8 @@ func TestServer_Run(t *testing.T) {
 	eg.Go(func() error {
 		s := NewServer(l, mux)
 		return s.Run(ctx)
-
 	})
+
 	in := "message"
 	url := fmt.Sprintf("http://%s/%s", l.Addr().String(), in)
 	t.Logf("try request to %q", url)

--- a/server_test.go
+++ b/server_test.go
@@ -11,9 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func TestRun(t *testing.T) {
-	t.Skip("リファクタリング中")
-
+func TestServer_Run(t *testing.T) {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("failed to listen port %v", err)
@@ -21,8 +19,14 @@ func TestRun(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	eg, ctx := errgroup.WithContext(ctx)
+	mux := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
+	})
+
 	eg.Go(func() error {
-		return run(ctx)
+		s := NewServer(l, mux)
+		return s.Run(ctx)
+
 	})
 	in := "message"
 	url := fmt.Sprintf("http://%s/%s", l.Addr().String(), in)


### PR DESCRIPTION
`http.Server`型をラップした独自構造体を定義

- 動的に選択したポートをリッスンするためにnet.Listenr型を引数で受け取る
- ルーティングの設定も引数で受け取る→`Server`型の責務からHTTPサーバーのルーティングを分離