### PR TITLE
[SECTION-063] ルーティング定義を分離した「NewMux」を定義する

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,20 +5,12 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/http"
 	"os"
-	"os/signal"
-	"syscall"
-	"time"
 
 	"github.com/koh-yoshimoto/go_todo_app/config"
-	"golang.org/x/sync/errgroup"
 )
 
 func run(ctx context.Context) error {
-	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
 	cfg, err := config.New()
 	if err != nil {
 		return err
@@ -29,31 +21,9 @@ func run(ctx context.Context) error {
 	}
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with: %v", url)
-	s := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// コマンドラインで実験するため
-			time.Sleep(5 * time.Second)
-			fmt.Fprintf(w, "Hello, %s!", r.URL.Path[1:])
-		}),
-	}
-
-	eg, ctx := errgroup.WithContext(ctx)
-
-	eg.Go(func() error {
-		if err := s.Serve(l); err != nil &&
-			err != http.ErrServerClosed {
-			log.Printf("failed to close: %+v", err)
-			return err
-		}
-		return nil
-	})
-
-	<-ctx.Done()
-	if err := s.Shutdown(context.Background()); err != nil {
-		log.Printf("failed to shutdown: %+v", err)
-	}
-
-	return eg.Wait()
+	mux := NewMux()
+	s := NewServer(l, mux)
+	return s.Run(ctx)
 }
 
 func main() {

--- a/mux.go
+++ b/mux.go
@@ -1,0 +1,12 @@
+package main
+
+import "net/http"
+
+func NewMux() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		_, _ = w.Write([]byte(`{"status": "ok"}`))
+	})
+	return mux
+}

--- a/mux_test.go
+++ b/mux_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewMux(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/health", nil)
+	sut := NewMux()
+
+	sut.ServeHTTP(w, r)
+	resp := w.Result()
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	if resp.StatusCode != http.StatusOK {
+		t.Error("want status code 200, but", resp.StatusCode)
+	}
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+
+	want := `{"status": "ok"}`
+	if string(got) != want {
+		t.Errorf("want %q, but got %q", want, got)
+	}
+
+}

--- a/mux_test.go
+++ b/mux_test.go
@@ -28,5 +28,4 @@ func TestNewMux(t *testing.T) {
 	if string(got) != want {
 		t.Errorf("want %q, but got %q", want, got)
 	}
-
 }


### PR DESCRIPTION
### HTTPハンドラーの定義を分離する
どのようなハンドラーの実装をどのようなURLパスで公開するかルーティングする`NewMux`関数を実装
`*http.ServeMux`型の値ではなく、`http.Handloer`インターフェースにしておくことで内部実装に依存しない関数シグネチャとなる

### 「httptest」パッケージを使ったテスト
`httptest.NewRecorder`関数を使うと`ResponseWriter`インターフェースを満たす`*ResponseRecorder`型の値を取得することができる
`*ResponseRecorder`型の値をServeHTTP関数に渡したあとに`Result`メソッドを実行すると、クライアントが受け取るレスポンス内容が含まれる`http.Response`型の値を取得できる
`httptest.NewRequest`関数は同様にテスト用の`*http.Request`型の値を生成する