### PR TITLE
[SECTION-065] 「entity.Task」型の定義と永続化方法の仮実装

### DIFF
--- a/entity/task.go
+++ b/entity/task.go
@@ -1,0 +1,21 @@
+package entity
+
+import "time"
+
+type TaskID int64
+type TaskStatus string
+
+const (
+	TaskStatusTodo  TaskStatus = "todo"
+	TaskStatusDoing TaskStatus = "doing"
+	TaskStatusDone  TaskStatus = "done"
+)
+
+type Task struct {
+	ID      TaskID     `json:"id"`
+	Title   string     `json:"title"`
+	Status  TaskStatus `json:"status"`
+	Created time.Time  `json:"created"`
+}
+
+type Tasks []*Task

--- a/store/store.go
+++ b/store/store.go
@@ -1,0 +1,33 @@
+package store
+
+import (
+	"errors"
+
+	"github.com/koh-yoshimoto/go_todo_app/entity"
+)
+
+var (
+	Tasks = &TaskStore{Tasks: map[entity.TaskID]*entity.Task{}}
+
+	ErrNotfound = errors.New("not found")
+)
+
+type TaskStore struct {
+	LastID entity.TaskID
+	Tasks  map[entity.TaskID]*entity.Task
+}
+
+func (ts *TaskStore) Add(t *entity.Task) (entity.TaskID, error) {
+	ts.LastID++
+	t.ID = ts.LastID
+	ts.Tasks[t.ID] = t
+	return t.ID, nil
+}
+
+func (ts *TaskStore) All() entity.Tasks {
+	tasks := make([]*entity.Task, len(ts.Tasks))
+	for i, t := range ts.Tasks {
+		tasks[i+1] = t
+	}
+	return tasks
+}


### PR DESCRIPTION
### 「entity.Task」の定義
`ID`フィールドと`Status`フィールドにDefined Typeを使用して独自の型を定義している

> #### Defined Typeと型推論(Type inference)
> `_ = Task{ID: 1}`のようなコードはエラーにならない
> これは **型推論(Type inference)** の作用
> 型推論によってコンパイラが「`TaskID`型のフィールドが`1`で初期化されているめ、`1`は`TaskID`型の`1`である」と解釈している

### 「entity.Task」の永続化
`entity.Task`型を永続化する仮実装
`store`ディレクトリに`store.go`として保存