### PR TITLE
[FIX] Test for parallelization

### DIFF
--- a/handler/add_task_test.go
+++ b/handler/add_task_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAddTask(t *testing.T) {
-	t.Parallel()
 	type want struct {
 		status  int
 		rspFile string
@@ -40,7 +39,9 @@ func TestAddTask(t *testing.T) {
 
 	for n, tt := range tests {
 		tt := tt
-		t.Run(n, func(*testing.T) {
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
+
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest(
 				http.MethodPost,


### PR DESCRIPTION
### テスト並列化のコードがエラーになる原因を修正
`testing.T.Parallel`が`t.Parallel called multiple times [recovered]`となる原因を修正した
`testing.T.Run`に引数として渡していたサブテスト関数の定義に抜けがあった。
```go
t.Run(n, func(*testing.T) {
```
↓
```go
t.Run(n, func(t *testing.T) {
```