### PR TITLE
[SECTION-069] HTTPハンドラーをルーティングに設定する

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/caarlos0/env/v6 v6.10.1
+	github.com/go-chi/chi/v5 v5.0.8
 	github.com/google/go-cmp v0.5.9
 	golang.org/x/sync v0.1.0
 	gopkg.in/go-playground/validator.v9 v9.31.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/I
 github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
+github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=

--- a/mux.go
+++ b/mux.go
@@ -1,12 +1,25 @@
 package main
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/koh-yoshimoto/go_todo_app/handler"
+	"github.com/koh-yoshimoto/go_todo_app/store"
+	"gopkg.in/go-playground/validator.v9"
+)
 
 func NewMux() http.Handler {
-	mux := http.NewServeMux()
+	mux := chi.NewRouter()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		_, _ = w.Write([]byte(`{"status": "ok"}`))
 	})
+
+	v := validator.New()
+	at := &handler.AddTask{Store: store.Tasks, Validator: v}
+	mux.Post("/tasks", at.ServeHTTP)
+	lt := &handler.ListTask{Store: store.Tasks}
+	mux.Get("/tasks", lt.ServeHTTP)
 	return mux
 }


### PR DESCRIPTION
## 「github.com/go-chi/chi」を使用した柔軟なルーティング設定
`github.com/go-chi/chi`は`net/http`パッケージの型に準拠しているため選定
`chi.NewRouter`関数で取得できる`*chi.Mux`型の値は`http.Handler`インタ＝フェース満たすため、
`NewMux`関数の関数シグネチャを変更せずに内部実装を変更できる