### PR TITLE
[SECTION-072] MySQL実行環境の構築

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,29 @@ name: test
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        options: >-
+          --health-cmd "mysqladmin ping -h localhost"
+          --health-interval 20s
+          --health-timeout 10s
+          --health-retries 10
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: todo
+          MYSQL_USER: todo
+          MYSQL_PASSWORD: todo
     steps:
     - uses: actions/setup-go@v3
       with:
         go-version: '>=1.18'
     - uses: actions/checkout@v3
+    - run: |
+        go install github.com/k0kubun/sqldef/cmd/mysqldef@latest
+        mysqldef -u todo -p todo -h 127.0.0.1 -P 3306 todo < ./_tools/mysql/schema.sql
     - run: go test ./... -coverprofile=coverage.out
     - name: report coverage
       uses: k1LoW/octocov-action@v0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build build-local up down logs ps test
+.PHONY: help build build-local up down migrate logs ps test
 .DEFAULT_GOAL := help
 
 DOCKER_TAG := latest
@@ -14,6 +14,12 @@ up: ## Do docker compose up with hot reload
 
 down: ## Do docker compose down
 	docker compose down
+
+migrate: ## Migrate db
+	mysqldef -u todo -p todo -h 127.0.0.1 -P 33306 todo < ./_tools/mysql/schema.sql
+
+dry-migrate: ## Migrate db
+	mysqldef -u todo -p todo -h 127.0.0.1 -P 33306 todo --dry-run < ./_tools/mysql/schema.sql
 
 logs: ## Tail docker compose logs
 	docker compose logs -f

--- a/_tools/mysql/conf.d/mysql.cnf
+++ b/_tools/mysql/conf.d/mysql.cnf
@@ -1,0 +1,2 @@
+[mysql]
+default_character_set=utf8mb4

--- a/_tools/mysql/conf.d/mysqld.cnf
+++ b/_tools/mysql/conf.d/mysqld.cnf
@@ -1,0 +1,4 @@
+[mysqld]
+default-authentication-plugin=mysql_native_password
+character_set_server=utf8mb4
+sql_mode=TRADITIONAL,NO_AUTO_VALUE_ON_ZERO,ONLY_FULL_GROUP_BY

--- a/_tools/mysql/schema.sql
+++ b/_tools/mysql/schema.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `user`
+(
+  `id`       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'ユーザーの識別子',
+  `name`     VARCHAR(20) NOT NULL COMMENT 'ユーザーの名前',
+  `password` VARCHAR(80) NOT NULL COMMENT 'パスワードハッシュ',
+  `role`     VARCHAR(80) NOT NULL COMMENT 'ロール',
+  `created`  DATETIME(6) NOT NULL COMMENT 'レコード作成日時',
+  `modified` DATETIME(6) NOT NULL COMMENT 'レコード修正日時',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uix_name` (`name`) USING BTREE
+)Engine=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='ユーザー';
+
+CREATE TABLE `task`
+(
+  `id`       BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'タスクの識別子',
+  `title`    VARCHAR(128) NOT NULL COMMENT 'タスクのタイトル',
+  `status`   VARCHAR(20) NOT NULL COMMENT 'タスクの状態',
+  `created`  DATETIME(6) NOT NULL COMMENT 'レコード作成日時',
+  `modified` DATETIME(6) NOT NULL COMMENT 'レコード修正日時',
+  PRIMARY KEY (`id`)
+)Engine=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='タスク';
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,28 @@ services:
     environment:
       TODO_ENV: dev
       PORT: 8080
+      TODO_DB_HOST: todo-db
+      TODO_DB_PORT: 3306
+      TODO_DB_USER: todo
+      TODO_DB_PASSWORD: todo
+      TODO_DB_DATABASE: todo
     volumes:
       - .:/app
     ports:
       - 18000:8080
-
+  todo-db:
+    image: mysql:8.0.29
+    platform: linux/amd64
+    container_name: todo-db
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_USER: todo
+      MYSQL_PASSWORD: todo
+      MYSQL_DATABASE: todo
+    volumes:
+      - todo-db-data:/var/lib/mysql
+      - $PWD/_tools/mysql/conf.d:/etc/mysql/conf.d:cached
+    ports:
+      - "33306:3306"
+volumes:
+  todo-db-data:


### PR DESCRIPTION
### テーブル定義とマイグレーション方法の決定
* テーブル定義は`_tools/mysql/schema.sql`ファイルに記述
> Goでは**アンダースコアで名前が始まるディレクトリ**と**`testdata`**という名前のディレクトリはパッケージとして認識しない
* マイグレーションツールとして`github.com/k0kubun/sqldef`パッケージの`mysqldef`を使用

### ローカルマシン上でMySQLコンテナを起動する
* `_tools/mysql/conf.d/mysql.cnf`と`_tools/mysql/conf.d/mysqld.cnf`を用意
* `docker-compose.yml`を更新
  * `app`サービスへ環境変数でDB情報を渡すように追記
  * `todo-db`としてMySQLコンテナを起動する設定を追記

#### ローカルマシンでのマイグレーション実施
* `make migrate`をMakefileに追記（`mysqldef todo < ./_tools/mysql/schema.sql`）
*  `make dry-migrate`をMakefileに追記（`mysqldef todo --dry-run < ./_tools/mysql/schema.sql`）
> `--dry-run`オプションはマイグレーションのリハーサルコマンド
> 差分適用 DDL 文を生成するが適用はしない

### GitHub Actions上でMySQLコンテナを起動する
自動テストでも実際のRDBMSを使用したテストコードを実行するために、GitHub Actions上でMySQLコンテナを起動する
GitHub Actionsでは**サービスコンテナ**という方法でCI/CDワークフロー上で必要となるミドルウェアのコンテナを起動できる
