### PR TITLE
[SECTION-074] RDBMSに関わる機能に対してテストコードを実装する

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/koh-yoshimoto/go_todo_app
 go 1.18
 
 require (
-	github.com/benbjohnson/clock v1.3.0
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/go-chi/chi/v5 v5.0.8
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/jmoiron/sqlx v1.3.5
 	golang.org/x/sync v0.1.0
+	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 	gopkg.in/go-playground/validator.v9 v9.31.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
-github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/caarlos0/env/v6 v6.10.1 h1:t1mPSxNpei6M5yAeu1qtRdPAK29Nbcf/n3G7x+b3/II=
 github.com/caarlos0/env/v6 v6.10.1/go.mod h1:hvp/ryKXKipEkcuYjs9mI4bBCg+UI0Yhgm5Zu0ddvwc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -32,6 +30,8 @@ golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/store/task.go
+++ b/store/task.go
@@ -12,7 +12,7 @@ func (r *Repository) ListTasks(
 	tasks := entity.Tasks{}
 	sql := `SELECT
 				id, title,
-				status, createdm modified
+				status, created, modified
 			FROM task;`
 	if err := db.SelectContext(ctx, &tasks, sql); err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ func (r *Repository) AddTask(
 	t.Modified = r.Clocker.Now()
 	sql := `INSERT INTO task
 				(title, status, created, modified)
-			VALUES (?, ?, ? ?);`
+			VALUES (?, ?, ?, ?);`
 	result, err := db.ExecContext(
 		ctx, sql, t.Title, t.Status,
 		t.Created, t.Modified,

--- a/store/task_test.go
+++ b/store/task_test.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jmoiron/sqlx"
+	"github.com/koh-yoshimoto/go_todo_app/clock"
+	"github.com/koh-yoshimoto/go_todo_app/entity"
+	"github.com/koh-yoshimoto/go_todo_app/testutil"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func TestRepository_AddTask(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c := clock.FixedClocker{}
+	var wantID int64 = 20
+	okTask := &entity.Task{
+		Title:    "ok task",
+		Status:   "todo",
+		Created:  c.Now(),
+		Modified: c.Now(),
+	}
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	mock.ExpectExec(
+		// エスケープが必要
+		`INSERT INTO task \(title, status, created, modified\) VALUES \(\?, \?, \?, \?\)`,
+	).WithArgs(okTask.Title, okTask.Status, c.Now(), c.Now()).
+		WillReturnResult(sqlmock.NewResult(wantID, 1))
+
+	xdb := sqlx.NewDb(db, "mysql")
+	r := &Repository{Clocker: c}
+	if err := r.AddTask(ctx, xdb, okTask); err != nil {
+		t.Errorf("want no error, but got %v", err)
+	}
+}
+
+func TestRepository_ListTasks(t *testing.T) {
+	ctx := context.Background()
+	// entity.Taskを作成する他のテストケースと混ざるとテストがフェイルする
+	// そのため、トランザクションをはかることでこのテストケースの中だけのテーブル状態にする
+	tx, err := testutil.OpenDBForTest(t).BeginTxx(ctx, nil)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	wants := prepareTasks(ctx, t, tx)
+
+	sut := &Repository{}
+	gots, err := sut.ListTasks(ctx, tx)
+	if err != nil {
+		t.Fatalf("unexecuted error: %v", err)
+	}
+	if d := cmp.Diff(gots, wants); len(d) != 0 {
+		t.Errorf("differs: (-gots +wants)\n%s", d)
+	}
+
+}
+
+func prepareTasks(ctx context.Context, t *testing.T, con Execer) entity.Tasks {
+	t.Helper()
+	if _, err := con.ExecContext(ctx, "DELETE FROM task;"); err != nil {
+		t.Logf("failed to initialize task: %v", err)
+	}
+	c := clock.FixedClocker{}
+	wants := entity.Tasks{
+		{
+			Title: "want task 1", Status: "todo",
+			Created: c.Now(), Modified: c.Now(),
+		},
+		{
+			Title: "want task 2", Status: "todo",
+			Created: c.Now(), Modified: c.Now(),
+		},
+		{
+			Title: "want task 3", Status: "done",
+			Created: c.Now(), Modified: c.Now(),
+		},
+	}
+	result, err := con.ExecContext(ctx,
+		`INSERT INTO task (title, status, created, modified)
+			VALUES
+				(?, ?, ?, ?),
+				(?, ?, ?, ?),
+				(?, ?, ?, ?);`,
+		wants[0].Title, wants[0].Status, wants[0].Created, wants[0].Modified,
+		wants[1].Title, wants[1].Status, wants[1].Created, wants[1].Modified,
+		wants[2].Title, wants[2].Status, wants[2].Created, wants[2].Modified,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wants[0].ID = entity.TaskID(id)
+	wants[1].ID = entity.TaskID(id + 1)
+	wants[2].ID = entity.TaskID(id + 2)
+
+	return wants
+}

--- a/testutil/db.go
+++ b/testutil/db.go
@@ -1,0 +1,31 @@
+package testutil
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+)
+
+func OpenDBForTest(t *testing.T) *sqlx.DB {
+	t.Helper()
+
+	port := 33306
+	if _, defined := os.LookupEnv("CI"); defined {
+		port = 3306
+	}
+	db, err := sql.Open(
+		"mysql",
+		fmt.Sprintf("todo:todo@tcp(127.0.0.1:%d)/todo?parseTime=true", port),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(
+		func() { _ = db.Close() },
+	)
+	return sqlx.NewDb(db, "mysql")
+}


### PR DESCRIPTION
### 実行環境によって接続情報を変更するテストヘルパー関数
テストコードをローカルマシン環境やGitHub Actions上で実行するには、環境別のMySQLへの接続情報が必要
次の理由により環境変数からではなく、実行環境に応じてハードコーディングされた接続情報を切り替える

* ローカルマシン環境は「docker-compose.yml」で接続情報が固定化されている
* GitHub Actions上の接続情報もGitHub Actionsの定義ファイルで固定化されている
* テストを実行するために固定化された接続情報を環境変数から読み込むのは非効率である

### 実際のRDBMSを使ってテストする
* テーブル状態を整える`prepareTasks`関数を準備
* RDBMSのトランザクション機能を使用してテストコードのためのテーブル状態を準備
> 複数レコードをつくったときの`sql.Result.LastInsertId`メソッドの戻り値はMySQLでは発行したレコードで最も小さい`ID`となる

### モックを使ってテストする
単体テストに相当するテストコードでRDBMSに依存したテストコードを書きたくない場合は、
`github.com/DATA-DOG/go-sqlmock`パッケージを使うとよい
テスト対象のメソッドから発行されたSQLクエリを検証することができる
トランザクションを利用する実装の場合も、`COMMIT/ROLLBACK`が期待通り発行されたかを検証することができる