### PR TITLE
[SECTION-075] HTTPハンドラーからRDBMSを使った永続化を行う

### DIFF
--- a/handler/add_task.go
+++ b/handler/add_task.go
@@ -3,15 +3,16 @@ package handler
 import (
 	"encoding/json"
 	"net/http"
-	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/koh-yoshimoto/go_todo_app/entity"
 	"github.com/koh-yoshimoto/go_todo_app/store"
 	"gopkg.in/go-playground/validator.v9"
 )
 
 type AddTask struct {
-	Store     *store.TaskStore
+	DB        *sqlx.DB
+	Repo      *store.Repository
 	Validator *validator.Validate
 }
 
@@ -35,12 +36,10 @@ func (at *AddTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	t := &entity.Task{
-		Title:   b.Title,
-		Status:  entity.TaskStatusTodo,
-		Created: time.Now(),
+		Title:  b.Title,
+		Status: entity.TaskStatusTodo,
 	}
-
-	id, err := store.Tasks.Add(t)
+	err = at.Repo.AddTask(ctx, at.DB, t)
 	if err != nil {
 		RespondJSON(ctx, w, &ErrResponse{
 			Message: err.Error(),
@@ -49,7 +48,7 @@ func (at *AddTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	rsp := struct {
 		ID int `json:"id"`
-	}{ID: id}
+	}{ID: int(t.ID)}
 
 	RespondJSON(ctx, w, rsp, http.StatusOK)
 }

--- a/handler/list_task.go
+++ b/handler/list_task.go
@@ -3,12 +3,14 @@ package handler
 import (
 	"net/http"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/koh-yoshimoto/go_todo_app/entity"
 	"github.com/koh-yoshimoto/go_todo_app/store"
 )
 
 type ListTask struct {
-	Store *store.TaskStore
+	DB   *sqlx.DB
+	Repo *store.Repository
 }
 
 type task struct {
@@ -19,7 +21,13 @@ type task struct {
 
 func (lt *ListTask) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	tasks := lt.Store.All()
+	tasks, err := lt.Repo.ListTasks(ctx, lt.DB)
+	if err != nil {
+		RespondJSON(ctx, w, &ErrResponse{
+			Message: err.Error(),
+		}, http.StatusInternalServerError)
+		return
+	}
 	rsp := []task{}
 	for _, t := range tasks {
 		rsp = append(rsp, task{

--- a/main.go
+++ b/main.go
@@ -21,14 +21,18 @@ func run(ctx context.Context) error {
 	}
 	url := fmt.Sprintf("http://%s", l.Addr().String())
 	log.Printf("start with: %v", url)
-	mux := NewMux()
+	mux, cleanup, err := NewMux(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
 	s := NewServer(l, mux)
 	return s.Run(ctx)
 }
 
 func main() {
 	if err := run(context.Background()); err != nil {
-		fmt.Printf("failed to terminate server: %v", err)
+		log.Printf("failed to terminate server: %v", err)
 		os.Exit(1)
 	}
 }

--- a/mux.go
+++ b/mux.go
@@ -1,15 +1,18 @@
 package main
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/koh-yoshimoto/go_todo_app/clock"
+	"github.com/koh-yoshimoto/go_todo_app/config"
 	"github.com/koh-yoshimoto/go_todo_app/handler"
 	"github.com/koh-yoshimoto/go_todo_app/store"
 	"gopkg.in/go-playground/validator.v9"
 )
 
-func NewMux() http.Handler {
+func NewMux(ctx context.Context, cfg *config.Config) (http.Handler, func(), error) {
 	mux := chi.NewRouter()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -17,9 +20,15 @@ func NewMux() http.Handler {
 	})
 
 	v := validator.New()
-	at := &handler.AddTask{Store: store.Tasks, Validator: v}
+	db, cleanup, err := store.New(ctx, cfg)
+	if err != nil {
+		return nil, cleanup, err
+	}
+	r := store.Repository{Clocker: clock.RealClocker{}}
+
+	at := &handler.AddTask{DB: db, Repo: &r, Validator: v}
 	mux.Post("/tasks", at.ServeHTTP)
-	lt := &handler.ListTask{Store: store.Tasks}
+	lt := &handler.ListTask{DB: db, Repo: &r}
 	mux.Get("/tasks", lt.ServeHTTP)
-	return mux
+	return mux, cleanup, nil
 }

--- a/store/repository.go
+++ b/store/repository.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/koh-yoshimoto/go_todo_app/clock"
 	"github.com/koh-yoshimoto/go_todo_app/config"
@@ -14,7 +15,7 @@ import (
 func New(ctx context.Context, cfg *config.Config) (*sqlx.DB, func(), error) {
 	db, err := sql.Open("mysql",
 		fmt.Sprintf(
-			"%s:%s@tcp(%s;%d)/%s?parseTIme=true",
+			"%s:%s@tcp(%s:%d)/%s?parseTime=true",
 			cfg.DBUser, cfg.DBPassword,
 			cfg.DBHost, cfg.DBPort,
 			cfg.DBName,


### PR DESCRIPTION
### このままの実装でテストを修正する？
RDBMSを使った永続化も行うようになり、HTTPハンドラーの実装には種類の異なる複数の処理が含まれることになった

* HTTPリクエストから必要な情報を読み取る
* HTTPレスポンスを構築してレスポンスを返す
* アプリケーションロジック・ビジネスロジックを実行する
* 「store」パッケージを呼び出して永続化処理を行う

これらが強く結合してくるとテストコードの作成が困難になる
責務を複数の実装に分離することでそれぞれの責務を疎結合にする
次のタスクとして、以下の3つのパッケージにこれらを分割する

* HTTPリクエストとHTTPレスポンスの処理を行う「handler」パッケージ
* 永続化操作を行う「store」パッケージ
* 永続化操作とアプリケーションロジックやビジネスロジックの実装を組み合わせて期待される挙動を実装する「service」パッケージ

さらにインターフェースを挟むことで他のパッケージの実装内容に影響しないテストコードを実装していく