### PR TITLE
[SECTION-076] HTTPハンドラーの実装を分解する

### DIFF
--- a/handler/service.go
+++ b/handler/service.go
@@ -1,0 +1,15 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/koh-yoshimoto/go_todo_app/entity"
+)
+
+type ListTasksService interface {
+	ListTasks(ctx context.Context) (entity.Tasks, error)
+}
+
+type AddTaskServiceinterface interface {
+	AddTask(ctx context.Context, title string) (entity.Task, error)
+}


### PR DESCRIPTION
### `handler`パッケージからビジネスロジックと永続化に関わる処理を取り除く
リクエストの解釈とレスポンスを組み立てる処理以外を新しく定義するインターフェースに移譲する

`handler/service.go`ファイルに`handler.ListTasksService`と`handler.AddTaskService`インターフェースの定義を行う

#### 構造体や関数ではなくインターフェースを定義する理由
* 他パッケージへの参照を取り除いて疎なパッケージ構成にするため
* インターフェースを介して特定の方に依存しないことでモックに処理を入れ替えたテストを行うため