### PR TITLE
[SECTION-078] 「go generate」コマンドを用いたモックの自動生成

### DIFF
--- a/handler/service.go
+++ b/handler/service.go
@@ -6,6 +6,7 @@ import (
 	"github.com/koh-yoshimoto/go_todo_app/entity"
 )
 
+//go:generate go run github.com/matryer/moq -outmoq_test.go . ListTasksService AddTaskService
 type ListTasksService interface {
 	ListTasks(ctx context.Context) (entity.Tasks, error)
 }

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,5 @@
+//go:build tools
+
+package main
+
+import _ "github.com/matryer/moq"


### PR DESCRIPTION
#### `//go:generate`に関して
`//go:generate`から始まるコメントはその後に続くコマンドでソースコードを自動生成するための記述
`go generate`コマンドによって手動実行される
`go run`で始まっている通り、Go製のツールであれば`go install`を使わずとも実行できる

#### バージョンの固定
`go run`コマンドを使うと実行タイミングにより最新バージョンのプログラムが実行されるという問題がある
この場合は、該当ツールを`import`した`tools.go`ファイルを定義しておくことで`go.mod`によるバージョン管理ができる
実アプリケーションのビルド時には無視されるように`tools.go`ファイルには`go:build`タグで`tools`を指定している

### 「github.com/matryer/moq」パッケージ
`github.com/matryer/moq`パッケージを利用してモックコードを`go generate`コマンドで自動生成する

> Goには`github.com/golang/mock`パッケージ(`gomock`)という有名なモックコードの自動生成ライブラリが存在している
> ただ、このパッケージでは生成されたモックが振る舞いを設定する際に引数が`any`のセッターを利用する
> そのため型による恩恵が得られずミスを誘発しやすい